### PR TITLE
Add UpgradePending and ControlPlaneReferenceNotSet reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `UpgradePending` and `ControlPlaneReferenceNotSet` condition reasons.
+- Update code docs.
+
 ## [0.1.0] - 2020-11-30
 
 - Rename template repo.

--- a/pkg/conditions/controlplaneready.go
+++ b/pkg/conditions/controlplaneready.go
@@ -34,10 +34,17 @@ const (
 	// Below are condition reasons for ControlPlaneReady that are usually set
 	// when condition status is set to False.
 
+	// ControlPlaneReferenceNotSetReason is a condition reason that is set when
+	// ControlPlaneReady is set with status False because control plane reference
+	// is not set on Cluster object. When using this reason, the condition
+	// severity should be set to Warning.
+	ControlPlaneReferenceNotSetReason = "ControlPlaneReferenceNotSet"
+
 	// ControlPlaneObjectNotFoundReason is a condition reason that is set when
 	// ControlPlaneReady is set with status False because control plane object
-	// is not found. When using this reason, the condition severity should be
-	// set to Warning.
+	// is not found, but control plane reference is set. When using this reason,
+	// the condition severity should be set to Warning (in the future this might
+	// change to Error).
 	ControlPlaneObjectNotFoundReason = "ControlPlaneObjectNotFound"
 
 	// Waiting time during which ControlPlaneReady is set to False with

--- a/pkg/conditions/controlplaneready.go
+++ b/pkg/conditions/controlplaneready.go
@@ -43,8 +43,7 @@ const (
 	// ControlPlaneObjectNotFoundReason is a condition reason that is set when
 	// ControlPlaneReady is set with status False because control plane object
 	// is not found, but control plane reference is set. When using this reason,
-	// the condition severity should be set to Warning (in the future this might
-	// change to Error).
+	// the condition severity should be set to Warning.
 	ControlPlaneObjectNotFoundReason = "ControlPlaneObjectNotFound"
 
 	// Waiting time during which ControlPlaneReady is set to False with

--- a/pkg/conditions/infrastructureready.go
+++ b/pkg/conditions/infrastructureready.go
@@ -43,7 +43,7 @@ const (
 	// when InfrastructureReady is set with status False because corresponding
 	// provider-specific infrastructure object is not found, but infrastructure
 	// reference is set. When using this reason, the condition severity should
-	// be set to Warning (in the future this might change to error).
+	// be set to Warning.
 	InfrastructureObjectNotFoundReason = "InfrastructureObjectNotFound"
 
 	// Waiting time during which InfrastructureReady is set to False with

--- a/pkg/conditions/infrastructureready.go
+++ b/pkg/conditions/infrastructureready.go
@@ -41,8 +41,9 @@ const (
 
 	// InfrastructureObjectNotFoundReason is a condition reason that is set
 	// when InfrastructureReady is set with status False because corresponding
-	// provider-specific infrastructure object is not found. When using this
-	// reason, the condition severity should be set to Warning.
+	// provider-specific infrastructure object is not found, but infrastructure
+	// reference is set. When using this reason, the condition severity should
+	// be set to Warning (in the future this might change to error).
 	InfrastructureObjectNotFoundReason = "InfrastructureObjectNotFound"
 
 	// Waiting time during which InfrastructureReady is set to False with

--- a/pkg/conditions/upgrading.go
+++ b/pkg/conditions/upgrading.go
@@ -22,6 +22,11 @@ const (
 	// This is usually during or after creation, but can also be after
 	// restoring a CR from the backup.
 	UpgradeNotStartedReason = "UpgradeNotStarted"
+
+	// UpgradePendingReason is set when the upgrade has not started yet,
+	// but it is pending and it will start soon, because owner object has
+	// Upgrading condition with status set to True.
+	UpgradePendingReason = "UpgradePending"
 )
 
 // GetUpgrading tries to get Upgrading condition from the specified object. If


### PR DESCRIPTION
What's in the box:
- `ControlPlaneReferenceNotSet` reason used for `ControlPlaneReady` condition
- `UpgradePending` reason used for `Upgrading` condition

## Checklist

- [x] Update changelog in CHANGELOG.md.
